### PR TITLE
provide config to reverse sort changelog

### DIFF
--- a/cddagl/ui/views/main.py
+++ b/cddagl/ui/views/main.py
@@ -3300,7 +3300,11 @@ class UpdateGroupBox(QGroupBox):
             else:
                 changelog_sorted.update({new_date : [new_entry]})
 
-        for date in sorted(changelog_sorted):
+        dated_changelog = sorted(changelog_sorted)
+        if config_true(get_config_value('reverse_sort_changelog', 'False')):
+            dated_changelog = reversed(dated_changelog)
+
+        for date in dated_changelog:
             changelog_html.write('</ul>')
             changelog_html.write(
                     '<h3>{0}</h3>'

--- a/cddagl/ui/views/settings.py
+++ b/cddagl/ui/views/settings.py
@@ -139,6 +139,18 @@ class LauncherSettingsGroupBox(QGroupBox):
         self.no_launcher_version_check_checkbox = (
             no_launcher_version_check_checkbox)
 
+        reverse_sort_changelog_checkbox = QCheckBox()
+        check_state = (Qt.Checked if config_true(get_config_value(
+            'reverse_sort_changelog', 'False')) 
+            else Qt.Unchecked)
+        reverse_sort_changelog_checkbox.setCheckState(
+            check_state)
+        reverse_sort_changelog_checkbox.stateChanged.connect(
+            self.rsc_changed)
+        layout.addWidget(reverse_sort_changelog_checkbox, 5, 0, 1, 2)
+        self.reverse_sort_changelog_checkbox = (
+            reverse_sort_changelog_checkbox)
+
         self.setLayout(layout)
         self.set_text()
 
@@ -158,6 +170,8 @@ class LauncherSettingsGroupBox(QGroupBox):
             'the launcher to be started'))
         self.no_launcher_version_check_checkbox.setText(_('Do not check '
             'for new version of the CDDA Game Launcher on launch'))
+        self.reverse_sort_changelog_checkbox.setText(_('Reverse sort '
+            'changelog'))
         self.setTitle(_('Launcher'))
 
     @property
@@ -205,6 +219,9 @@ class LauncherSettingsGroupBox(QGroupBox):
     def nlvcc_changed(self, state):
         set_config_value('prevent_version_check_launch',
             str(state != Qt.Unchecked))
+
+    def rsc_changed(self, state):
+        set_config_value('reverse_sort_changelog', str(state != Qt.Unchecked))
 
     def klo_changed(self, state):
         checked = state != Qt.Unchecked


### PR DESCRIPTION
resolves https://github.com/DazedNConfused-/CDDA-Game-Launcher/issues/55

I have added a new config option in settings page to turn on sorting changelog in reverse order, so that most recent days come first.  I have default value to false to maintain current display order, though I think we may want to make this the default order.