### PR TITLE
Downloading soundpacks sometimes doesn't show known total file size

### DIFF
--- a/cddagl/ui/views/soundpacks.py
+++ b/cddagl/ui/views/soundpacks.py
@@ -51,6 +51,7 @@ class SoundpacksTab(QTabWidget):
 
         self.soundpacks = []
         self.soundpacks_model = None
+        self.selected_size = -1 
 
         self.installing_new_soundpack = False
         self.downloading_new_soundpack = False
@@ -389,6 +390,11 @@ class SoundpacksTab(QTabWidget):
                 self.downloading_progress_bar = progress_bar
                 progress_bar.setMinimum(0)
 
+                self.selected_size = -1
+                if 'size' in selected_info:
+                    self.selected_size = selected_info['size']
+                    self.downloading_progress_bar.setMaximum(self.selected_size)
+
                 self.download_last_read = datetime.utcnow()
                 self.download_last_bytes_read = 0
                 self.download_speed_count = 0
@@ -684,14 +690,19 @@ class SoundpacksTab(QTabWidget):
         self.downloading_file.write(self.download_http_reply.readAll())
 
     def download_dl_progress(self, bytes_read, total_bytes):
-        self.downloading_progress_bar.setMaximum(total_bytes)
+        if total_bytes != -1:
+            self.downloading_progress_bar.setMaximum(total_bytes)
         self.downloading_progress_bar.setValue(bytes_read)
 
         self.download_speed_count += 1
 
+        if total_bytes == -1:
+            size = self.selected_size
+        else:
+            size = total_bytes
         self.downloading_size_label.setText(
             '{bytes_read}/{total_bytes}'
-            .format(bytes_read=sizeof_fmt(bytes_read), total_bytes=sizeof_fmt(total_bytes))
+            .format(bytes_read=sizeof_fmt(bytes_read), total_bytes=sizeof_fmt(size))
         )
 
         if self.download_speed_count % 5 == 0:


### PR DESCRIPTION
Fixes https://github.com/remyroy/CDDA-Game-Launcher/issues/660

The current downloading progress reporting relies on Qt's downloadProgress signal <https://doc.qt.io/qt-5/qnetworkreply.html#downloadProgress> which includes a bytesTotal value that is assumed to be the total number of bytes expected. Kind of what you would expect.
Except or the bit that says 'If the number of bytes to be downloaded is not known, bytesTotal will be -1', which is happening in some cases, overriding the known size from soundpacks.json.

This fix remembers any defined size for the selected soundpack and uses that in the statusbar if we get a bytesTotal == -1.

Testing: Download soundpacks where 
(a) there was a defined size:
![launcher-downloadsoundpack1](https://user-images.githubusercontent.com/77873080/214224732-7213f2e1-92c0-4f98-ac12-ab94717eac1a.jpg)

(b) there was no defined size:
![launcher-downloadsoundpack2](https://user-images.githubusercontent.com/77873080/214224778-345934ca-0e5a-42b2-b899-41e2f12b9a7f.jpg)
In this case the downloadProgress signal did know what size to expect. 

Note:
This is a largely cosmetic issue, so no hurry to release.
