### PR TITLE
All builds 'unavailable'

### DIFF
--- a/cddagl/constants.py
+++ b/cddagl/constants.py
@@ -45,11 +45,11 @@ BASE_ASSETS = {
     'Tiles': {
         'x64': {
             'Platform': 'x64',
-            'Graphics': 'tiles'
+            'Graphics': 'with-graphics-and-sounds'
         },
         'x86': {
             'Platform': 'x32',
-            'Graphics': 'tiles'
+            'Graphics': 'with-graphics-and-sounds'
         }
     }
 }


### PR DESCRIPTION
Since (about) October 2024 all builds in the 'Available builds' dropdown show as 'Unavailable':
![01-Unavailable-builds](https://github.com/user-attachments/assets/c22f843d-b342-437a-829d-23d9ee3eea9a)

If you attempt an update, there is an immediate error message:
![02-Errno2](https://github.com/user-attachments/assets/c90c441d-dbcb-4786-8de5-fd5bb53b51b0)

After investigation, it appears that builds are now labelled with a different pattern.
Instead of being called things like '...windows-**tiles**-x64...' they are now '...windows-**with-graphics-and-sounds**-x64...' (and similarly for the x32 builds). This change means that the regular expression used to locate the correct build within each release fails.

It turns out these patterns are conveniently parameterized in 'constants.py', so we just need to update that.

### Testing
After the change, the builds are now available.
![03-Available-builds](https://github.com/user-attachments/assets/a537a6e5-95ff-4be0-b293-16dcd4592b48)

The update process also works again.

### Alternative solutions
There are also '...windows-**with-graphics**-x64...' (ie no sounds) builds. 
I don't use sounds so I don't know if they get addressed separately - presumably the no sounds build is a smaller download so would be preferred if the sounds are not required.